### PR TITLE
OpenMP parallelization of common loops

### DIFF
--- a/src/OpenFOAM/containers/Lists/List/List.C
+++ b/src/OpenFOAM/containers/Lists/List/List.C
@@ -32,6 +32,7 @@ License
 #include "PtrList.H"
 #include "SLList.H"
 #include "contiguous.H"
+#include "macros.H"
 #include <utility>
 
 // * * * * * * * * * * * * * Private Member Functions  * * * * * * * * * * * //
@@ -127,6 +128,7 @@ Foam::List<T>::List(const label len, const T& val)
         doAlloc();
 
         List_ACCESS(T, (*this), vp);
+        OMP(parallel for if(len >= (1<<21)))
         for (label i=0; i < len; ++i)
         {
             vp[i] = val;
@@ -152,6 +154,7 @@ Foam::List<T>::List(const label len, const Foam::zero)
         doAlloc();
 
         List_ACCESS(T, (*this), vp);
+        OMP(parallel for if(len >= (1<<21)))
         for (label i=0; i < len; ++i)
         {
             vp[i] = Zero;
@@ -211,6 +214,7 @@ Foam::List<T>::List(const UList<T>& a)
         {
             List_ACCESS(T, (*this), vp);
             List_CONST_ACCESS(T, a, ap);
+            OMP(parallel for if(len >= (1<<21)))
             for (label i = 0; i < len; ++i)
             {
                 vp[i] = ap[i];
@@ -244,6 +248,7 @@ Foam::List<T>::List(const List<T>& a)
         {
             List_ACCESS(T, (*this), vp);
             List_CONST_ACCESS(T, a, ap);
+            OMP(parallel for if(len >= (1<<21)))
             for (label i = 0; i < len; ++i)
             {
                 vp[i] = ap[i];
@@ -286,6 +291,7 @@ Foam::List<T>::List(List<T>& a, bool reuse)
         {
             List_ACCESS(T, (*this), vp);
             List_CONST_ACCESS(T, a, ap);
+            OMP(parallel for if(len >= (1<<21)))
             for (label i = 0; i < len; ++i)
             {
                 vp[i] = ap[i];
@@ -308,6 +314,7 @@ Foam::List<T>::List(const UList<T>& list, const labelUList& indices)
 
         List_ACCESS(T, (*this), vp);
 
+        OMP(parallel for if(len >= (1<<21)))
         for (label i=0; i < len; ++i)
         {
             vp[i] = list[indices[i]];
@@ -332,6 +339,7 @@ Foam::List<T>::List
 
     List_ACCESS(T, (*this), vp);
 
+    OMP(parallel for if(len >= (1<<21)))
     for (label i=0; i < len; ++i)
     {
         vp[i] = list[indices[i]];
@@ -503,6 +511,7 @@ void Foam::List<T>::operator=(const UList<T>& a)
         {
             List_ACCESS(T, (*this), vp);
             List_CONST_ACCESS(T, a, ap);
+            OMP(parallel for if(len >= (1<<21)))
             for (label i = 0; i < len; ++i)
             {
                 vp[i] = ap[i];

--- a/src/OpenFOAM/containers/Lists/List/ListLoopM.H
+++ b/src/OpenFOAM/containers/Lists/List/ListLoopM.H
@@ -45,9 +45,13 @@ Description
 #define List_CONST_ACCESS(type, f, fp)          \
     const type* const __restrict__ fp = (f).begin()
 
-#define List_FOR_ALL(f, i)                      \
+#define List_FOR_ALL_PARALLEL(f, i)             \
         const label _n##i = (f).size();         \
         OMP(parallel for if(_n##i >= (1<<21)))  \
+        for (label i=0; i<_n##i; ++i)
+
+#define List_FOR_ALL(f, i)                      \
+        const label _n##i = (f).size();         \
         for (label i=0; i<_n##i; ++i)
 
 // Current element (non-const access)

--- a/src/OpenFOAM/containers/Lists/List/ListLoopM.H
+++ b/src/OpenFOAM/containers/Lists/List/ListLoopM.H
@@ -32,6 +32,8 @@ Description
 #ifndef ListLoopM_H
 #define ListLoopM_H
 
+#include "macros.H"
+
 // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
 // Element access looping
 
@@ -45,6 +47,7 @@ Description
 
 #define List_FOR_ALL(f, i)                      \
         const label _n##i = (f).size();         \
+        OMP(parallel for if(_n##i >= (1<<21)))  \
         for (label i=0; i<_n##i; ++i)
 
 // Current element (non-const access)

--- a/src/OpenFOAM/containers/Lists/List/UList.C
+++ b/src/OpenFOAM/containers/Lists/List/UList.C
@@ -30,6 +30,7 @@ License
 #include "ListLoopM.H"
 #include "contiguous.H"
 #include "labelRange.H"
+#include "macros.H"
 
 #include <algorithm>
 #include <random>
@@ -58,6 +59,7 @@ void Foam::UList<T>::moveFirst(const label i)
 {
     checkIndex(i);
 
+    OMP(parallel for if(i >= (1<<21)))
     for (label lower = 0; lower < i; ++lower)
     {
         Foam::Swap(this->operator[](lower), this->operator[](i));
@@ -70,6 +72,7 @@ void Foam::UList<T>::moveLast(const label i)
 {
     checkIndex(i);
 
+    OMP(parallel for if(i >= (1<<21)))
     for (label upper = size()-1; upper > i; --upper)
     {
         Foam::Swap(this->operator[](i), this->operator[](upper));
@@ -130,6 +133,7 @@ void Foam::UList<T>::deepCopy(const UList<T>& list)
         {
             List_ACCESS(T, (*this), lhs);
             List_CONST_ACCESS(T, list, rhs);
+            OMP(parallel for if(len >= (1<<21)))
             for (label i = 0; i < len; ++i)
             {
                 lhs[i] = rhs[i];
@@ -155,6 +159,7 @@ void Foam::UList<T>::deepCopy(const IndirectListBase<T, Addr>& list)
     else if (len)
     {
         List_ACCESS(T, (*this), lhs);
+        OMP(parallel for if(len >= (1<<21)))
         for (label i = 0; i < len; ++i)
         {
             lhs[i] = list[i];
@@ -172,6 +177,7 @@ void Foam::UList<T>::operator=(const T& val)
 
     List_ACCESS(T, (*this), vp);
 
+    OMP(parallel for if(len >= (1<<21)))
     for (label i=0; i < len; ++i)
     {
         vp[i] = val;
@@ -186,6 +192,7 @@ void Foam::UList<T>::operator=(const Foam::zero)
 
     List_ACCESS(T, (*this), vp);
 
+    OMP(parallel for if(len >= (1<<21)))
     for (label i=0; i < len; ++i)
     {
         vp[i] = Zero;

--- a/src/OpenFOAM/fields/Fields/Field/FieldM.H
+++ b/src/OpenFOAM/fields/Fields/Field/FieldM.H
@@ -123,7 +123,7 @@ void checkFields
     List_CONST_ACCESS(typeF2, f2, f2P);                                        \
                                                                                \
     /* Loop: f1 OP FUNC(f2) */                                                 \
-    List_FOR_ALL(f1, i)                                                        \
+    List_FOR_ALL_PARALLEL(f1, i)                                                        \
     {                                                                          \
         (f1P[i]) OP FUNC(f2P[i]);                                              \
     }
@@ -139,7 +139,7 @@ void checkFields
     List_CONST_ACCESS(typeF2, f2, f2P);                                        \
                                                                                \
     /* Loop: f1 OP f2.FUNC() */                                                \
-    List_FOR_ALL(f1, i)                                                        \
+    List_FOR_ALL_PARALLEL(f1, i)                                                        \
     {                                                                          \
         (f1P[i]) OP (f2P[i]).FUNC();                                           \
     }
@@ -158,7 +158,7 @@ void checkFields
     List_CONST_ACCESS(typeF3, f3, f3P);                                        \
                                                                                \
     /* Loop: f1 OP FUNC(f2, f3) */                                             \
-    List_FOR_ALL(f1, i)                                                        \
+    List_FOR_ALL_PARALLEL(f1, i)                                               \
     {                                                                          \
         (f1P[i]) OP FUNC((f2P[i]), (f3P[i]));                                  \
     }
@@ -194,7 +194,7 @@ void checkFields
     List_CONST_ACCESS(typeF2, f2, f2P);                                        \
                                                                                \
     /* Loop: f1 OP FUNC(f2, s) */                                              \
-    List_FOR_ALL(f1, i)                                                        \
+    List_FOR_ALL_PARALLEL(f1, i)                                               \
     {                                                                          \
         (f1P[i]) OP FUNC((f2P[i]), (s));                                       \
     }
@@ -226,7 +226,7 @@ void checkFields
     List_CONST_ACCESS(typeF2, f2, f2P);                                        \
                                                                                \
     /* Loop: f1 OP1 f2 OP2 f3 */                                               \
-    List_FOR_ALL(f1, i)                                                        \
+    List_FOR_ALL_PARALLEL(f1, i)                                               \
     {                                                                          \
         (f1P[i]) OP FUNC((s), (f2P[i]));                                       \
     }
@@ -240,7 +240,7 @@ void checkFields
     List_ACCESS(typeF1, f1, f1P);                                              \
                                                                                \
     /* Loop: f1 OP FUNC(s1, s2) */                                             \
-    List_FOR_ALL(f1, i)                                                        \
+    List_FOR_ALL_PARALLEL(f1, i)                                               \
     {                                                                          \
         (f1P[i]) OP FUNC((s1), (s2));                                          \
     }
@@ -258,7 +258,7 @@ void checkFields
     List_CONST_ACCESS(typeF2, f2, f2P);                                        \
                                                                                \
     /* Loop: f1 OP f2 FUNC(s) */                                               \
-    List_FOR_ALL(f1, i)                                                        \
+    List_FOR_ALL_PARALLEL(f1, i)                                               \
     {                                                                          \
         (f1P[i]) OP (f2P[i]) FUNC((s));                                        \
     }
@@ -277,7 +277,7 @@ void checkFields
     List_CONST_ACCESS(typeF3, f3, f3P);                                        \
                                                                                \
     /* Loop: f1 OP1 f2 OP2 f3 */                                               \
-    List_FOR_ALL(f1, i)                                                        \
+    List_FOR_ALL_PARALLEL(f1, i)                                               \
     {                                                                          \
         (f1P[i]) OP1 (f2P[i]) OP2 (f3P[i]);                                    \
     }
@@ -295,7 +295,7 @@ void checkFields
     List_CONST_ACCESS(typeF2, f2, f2P);                                        \
                                                                                \
     /* Loop: f1 OP1 s OP2 f2 */                                                \
-    List_FOR_ALL(f1, i)                                                        \
+    List_FOR_ALL_PARALLEL(f1, i)                                               \
     {                                                                          \
         (f1P[i]) OP1 (s) OP2 (f2P[i]);                                         \
     }
@@ -313,7 +313,7 @@ void checkFields
     List_CONST_ACCESS(typeF2, f2, f2P);                                        \
                                                                                \
     /* Loop f1 OP1 s OP2 f2 */                                                 \
-    List_FOR_ALL(f1, i)                                                        \
+    List_FOR_ALL_PARALLEL(f1, i)                                               \
     {                                                                          \
         (f1P[i]) OP1 (f2P[i]) OP2 (s);                                         \
     }
@@ -331,7 +331,7 @@ void checkFields
     List_CONST_ACCESS(typeF2, f2, f2P);                                        \
                                                                                \
     /* Loop: f1 OP f2 */                                                       \
-    List_FOR_ALL(f1, i)                                                        \
+    List_FOR_ALL_PARALLEL(f1, i)                                               \
     {                                                                          \
         (f1P[i]) OP (f2P[i]);                                                  \
     }
@@ -348,7 +348,7 @@ void checkFields
     List_CONST_ACCESS(typeF2, f2, f2P);                                        \
                                                                                \
     /* Loop: f1 OP1 OP2 f2 */                                                  \
-    List_FOR_ALL(f1, i)                                                        \
+    List_FOR_ALL_PARALLEL(f1, i)                                               \
     {                                                                          \
         (f1P[i]) OP1 OP2 (f2P[i]);                                             \
     }
@@ -362,7 +362,7 @@ void checkFields
     List_ACCESS(typeF, f, fP);                                                 \
                                                                                \
     /* Loop: f OP s */                                                         \
-    List_FOR_ALL(f, i)                                                         \
+    List_FOR_ALL_PARALLEL(f, i)                                                \
     {                                                                          \
         (fP[i]) OP (s);                                                        \
     }

--- a/src/OpenFOAM/fields/GeometricFields/GeometricField/GeometricBoundaryField.C
+++ b/src/OpenFOAM/fields/GeometricFields/GeometricField/GeometricBoundaryField.C
@@ -447,6 +447,7 @@ void Foam::GeometricBoundaryField<Type, PatchField, GeoMesh>::evaluate()
     {
         const label startOfRequests = UPstream::nRequests();
 
+        OMP(parallel for if(this->size() >= (1<<21)))
         for (auto& pfld : *this)
         {
             pfld.initEvaluate(commsType);
@@ -462,6 +463,7 @@ void Foam::GeometricBoundaryField<Type, PatchField, GeoMesh>::evaluate()
             UPstream::waitRequests(startOfRequests);
         }
 
+        OMP(parallel for if(this->size() >= (1<<21)))
         for (auto& pfld : *this)
         {
             pfld.evaluate(commsType);

--- a/src/OpenFOAM/include/macros.H
+++ b/src/OpenFOAM/include/macros.H
@@ -62,6 +62,12 @@ Description
 //- Macro to stringify macro contents
 #define STRING_QUOTE(input) STRINGIFY(input)
 
+//- Conditional #pragma omp <X>, expands to nothing when OpenMP is not enabled
+#ifdef USE_OMP
+#define OMP(X) _Pragma(STRING_QUOTE(omp X))
+#else
+#define OMP(X)
+#endif
 
 // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
 

--- a/src/OpenFOAM/meshes/primitiveMesh/primitiveMeshCheck/primitiveMeshTools.C
+++ b/src/OpenFOAM/meshes/primitiveMesh/primitiveMeshCheck/primitiveMeshTools.C
@@ -45,6 +45,7 @@ void Foam::primitiveMeshTools::updateFaceCentresAndAreas
 {
     const faceList& fs = mesh.faces();
 
+    OMP(parallel for if(faceIDs.size() >= (1<<21)))
     for (const label facei : faceIDs)
     {
         const labelList& f = fs[facei];

--- a/src/OpenFOAM/primitives/AtomicAccumulator/AtomicAccumulator.H
+++ b/src/OpenFOAM/primitives/AtomicAccumulator/AtomicAccumulator.H
@@ -1,0 +1,65 @@
+#ifndef AtomicAccumulator_H
+#define AtomicAccumulator_H
+
+#include "VectorSpace.H"
+#include "VectorSpaceOps.H"
+#include "macros.H"
+#include "ops.H"
+
+#include <type_traits>
+
+namespace Foam {
+
+template <typename T>
+class AtomicAccumulator {
+private:
+    T* val;
+public:
+    static_assert(std::is_scalar<T>::value, "T must be a scalar type");
+
+    AtomicAccumulator(T &ref) : val(&ref) {}
+    inline void operator+=(const T& rhs)
+    {
+        OMP(atomic update)
+        *val += rhs;
+    }
+    inline void operator-=(const T& rhs)
+    {
+        OMP(atomic update)
+        *val -= rhs;
+    }
+};
+
+template <typename T>
+inline typename std::enable_if<std::is_scalar<T>::value, AtomicAccumulator<T>>::type atomicAccumulator(T& ref)
+{
+    return AtomicAccumulator<T>(ref);
+}
+
+template <class Form, class Cmpt, direction Ncmpts>
+class AtomicAccumulator<VectorSpace<Form, Cmpt, Ncmpts>> {
+private:
+    typedef VectorSpace<Form, Cmpt, Ncmpts> vector;
+
+    vector* val;
+public:
+    AtomicAccumulator(vector &ref) : val(&ref) {}
+    inline void operator+=(const vector& rhs)
+    {
+        VectorSpaceOps<Ncmpts,0>::eqOp(*val, rhs, atomicPlusEqOp<Cmpt>());
+    }
+    inline void operator-=(const vector& rhs)
+    {
+        VectorSpaceOps<Ncmpts,0>::eqOp(*val, rhs, atomicMinusEqOp<Cmpt>());
+    }
+};
+
+template <class Form, class Cmpt, direction Ncmpts>
+inline AtomicAccumulator<VectorSpace<Form, Cmpt, Ncmpts>> atomicAccumulator(VectorSpace<Form, Cmpt, Ncmpts>& ref)
+{
+    return AtomicAccumulator<VectorSpace<Form, Cmpt, Ncmpts>>(ref);
+}
+
+}
+
+#endif // AtomicAccumulator_H

--- a/src/OpenFOAM/primitives/ops/ops.H
+++ b/src/OpenFOAM/primitives/ops/ops.H
@@ -37,6 +37,8 @@ Description
 #ifndef Foam_ops_H
 #define Foam_ops_H
 
+#include "macros.H"
+
 // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
 
 namespace Foam
@@ -95,6 +97,38 @@ EqOp(nopEq, (void)x)
 
 #undef EqOp
 
+#define AtomicEqOp(opName, op, atomicClause)                                   \
+                                                                               \
+    template<class T1, class T2>                                               \
+    struct atomic##opName##Op2                                                 \
+    {                                                                          \
+        void operator()(T1& x, const T2& y) const                              \
+        {                                                                      \
+            OMP(atomic atomicClause)                                           \
+            op;                                                                \
+        }                                                                      \
+    };                                                                         \
+                                                                               \
+    template<class T>                                                          \
+    struct atomic##opName##Op                                                  \
+    {                                                                          \
+        void operator()(T& x, const T& y) const                                \
+        {                                                                      \
+            OMP(atomic atomicClause)                                           \
+            op;                                                                \
+        }                                                                      \
+    };
+
+AtomicEqOp(Eq,         x = y,  write)
+AtomicEqOp(PlusEq,     x += y, update)
+AtomicEqOp(MinusEq,    x -= y, update)
+AtomicEqOp(MultiplyEq, x *= y, update)
+AtomicEqOp(DivideEq,   x /= y, update)
+AtomicEqOp(BitAndEq,   x &= y, update)
+AtomicEqOp(BitOrEq,    x |= y, update)
+AtomicEqOp(BitXorEq,   x ^= y, update)
+
+#undef AtomicEqOp
 
 // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
 

--- a/src/finiteVolume/finiteVolume/fvc/fvcSurfaceIntegrate.C
+++ b/src/finiteVolume/finiteVolume/fvc/fvcSurfaceIntegrate.C
@@ -64,7 +64,7 @@ void surfaceIntegrate
         atomicAccumulator(ivf[neighbour[facei]]) -= issf[facei];
     }
 
-    OMP(parallel for if(mesh.boundary().size() >= (1<<21)))
+    OMP(parallel for if(mesh.boundary().size() >= (1<<18)))
     forAll(mesh.boundary(), patchi)
     {
         const labelUList& pFaceCells =
@@ -164,12 +164,14 @@ surfaceSum
     const labelUList& owner = mesh.owner();
     const labelUList& neighbour = mesh.neighbour();
 
+    OMP(parallel for if(owner.size() >= (1<<21)))
     forAll(owner, facei)
     {
-        vf[owner[facei]] += ssf[facei];
-        vf[neighbour[facei]] += ssf[facei];
+        atomicAccumulator(vf[owner[facei]]) += ssf[facei];
+        atomicAccumulator(vf[neighbour[facei]]) += ssf[facei];
     }
 
+    OMP(parallel for if(mesh.boundary().size() >= (1<<18)))
     forAll(mesh.boundary(), patchi)
     {
         const labelUList& pFaceCells =
@@ -179,7 +181,7 @@ surfaceSum
 
         forAll(mesh.boundary()[patchi], facei)
         {
-            vf[pFaceCells[facei]] += pssf[facei];
+            atomicAccumulator(vf[pFaceCells[facei]]) += pssf[facei];
         }
     }
 

--- a/src/finiteVolume/finiteVolume/gradSchemes/gaussGrad/gaussGrad.C
+++ b/src/finiteVolume/finiteVolume/gradSchemes/gaussGrad/gaussGrad.C
@@ -89,7 +89,7 @@ Foam::fv::gaussGrad<Type>::gradf
         atomicAccumulator(igGrad[neighbour[facei]]) -= Sfssf;
     }
 
-    OMP(parallel for if(mesh.boundary().size() >= (1<<21)))
+    OMP(parallel for if(mesh.boundary().size() >= (1<<18)))
     forAll(mesh.boundary(), patchi)
     {
         const labelUList& pFaceCells =

--- a/src/finiteVolume/finiteVolume/gradSchemes/gaussGrad/gaussGrad.C
+++ b/src/finiteVolume/finiteVolume/gradSchemes/gaussGrad/gaussGrad.C
@@ -28,6 +28,8 @@ License
 
 #include "gaussGrad.H"
 #include "extrapolatedCalculatedFvPatchField.H"
+#include "AtomicAccumulator.H"
+#include "macros.H"
 
 // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
 
@@ -78,14 +80,16 @@ Foam::fv::gaussGrad<Type>::gradf
     Field<GradType>& igGrad = gGrad;
     const Field<Type>& issf = ssf;
 
+    OMP(parallel for if(owner.size() >= (1<<21)))
     forAll(owner, facei)
     {
         const GradType Sfssf = Sf[facei]*issf[facei];
 
-        igGrad[owner[facei]] += Sfssf;
-        igGrad[neighbour[facei]] -= Sfssf;
+        atomicAccumulator(igGrad[owner[facei]]) += Sfssf;
+        atomicAccumulator(igGrad[neighbour[facei]]) -= Sfssf;
     }
 
+    OMP(parallel for if(mesh.boundary().size() >= (1<<21)))
     forAll(mesh.boundary(), patchi)
     {
         const labelUList& pFaceCells =
@@ -97,7 +101,7 @@ Foam::fv::gaussGrad<Type>::gradf
 
         forAll(mesh.boundary()[patchi], facei)
         {
-            igGrad[pFaceCells[facei]] += pSf[facei]*pssf[facei];
+            atomicAccumulator(igGrad[pFaceCells[facei]]) += pSf[facei]*pssf[facei];
         }
     }
 

--- a/src/finiteVolume/interpolation/surfaceInterpolation/surfaceInterpolationScheme/surfaceInterpolationScheme.C
+++ b/src/finiteVolume/interpolation/surfaceInterpolation/surfaceInterpolationScheme/surfaceInterpolationScheme.C
@@ -262,6 +262,7 @@ Foam::surfaceInterpolationScheme<Type>::dotInterpolate
 
     const typename SFType::Internal& Sfi = Sf();
 
+    OMP(parallel for if(P.size() >= (1<<21)))
     for (label fi=0; fi<P.size(); fi++)
     {
         sfi[fi] = Sfi[fi] & (lambda[fi]*(vfi[P[fi]] - vfi[N[fi]]) + vfi[N[fi]]);
@@ -272,6 +273,7 @@ Foam::surfaceInterpolationScheme<Type>::dotInterpolate
     typename GeometricField<RetType, fvsPatchField, surfaceMesh>::
         Boundary& sfbf = sf.boundaryFieldRef();
 
+    OMP(parallel for if(lambdas.boundaryField().size() >= (1<<21)))
     forAll(lambdas.boundaryField(), pi)
     {
         const fvsPatchScalarField& pLambda = lambdas.boundaryField()[pi];

--- a/wmake/makefiles/general
+++ b/wmake/makefiles/general
@@ -56,6 +56,7 @@ SYS_INC         =
 SYS_LIBS        =
 
 PROJECT_INC     = \
+    $(COMP_OPENMP) \
     -I$(LIB_SRC)/$(WM_PROJECT)/lnInclude \
     -I$(LIB_SRC)/OSspecific/$(WM_OSTYPE)/lnInclude
 


### PR DESCRIPTION
This patch set enables OpenMP for all compilation units in OpenFOAM, but respects the `~openmp` option in `WM_COMPILE_OPTIONS` to disable it. Therefore the pragmas are wrapped in a conditional macro `OMP(...)`
The conditional parallelization based on the size is just a heuristic (more than one huge page), no effort was spent on tuning it, it might not be actually necessary.
The targeted regions were obtained by profilling the channel-reTau and Lid driven cavity benchmarks.