### PR TITLE
Openmp clang rules on v2312

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,15 @@
+## notes on installation
+Given that some roctx profiling calls are in openfoam macros it is necessary to
+add the relevant compiler flags to succesfully compile the code, this is done
+via FOAM_EXTRA environment variables
+
+    export ROCM4FOAM="path to your rocm installation"
+    export FOAM_EXTRA_CFLAGS="-DUSE_ROCTX -I${ROCM4FOAM}/roctracer/include/"
+    export FOAM_EXTRA_CXXFLAGS="-DUSE_ROCTX -I${ROCM4FOAM}/roctracer/include/"
+    export FOAM_EXTRA_LDFLAGS="${ROCM4FOAM}/lib/libroctx64.so -L${ROCM4FOAM}/lib 
+
+these must be set before compiling openfoam.
+
 ## About OpenFOAM
 OpenFOAM is a free, open source CFD software [released and developed by OpenCFD Ltd since 2004](http://www.openfoam.com/history/).
 It has a large user base across most areas of engineering and science, from both commercial and academic organisations.

--- a/etc/bashrc
+++ b/etc/bashrc
@@ -90,6 +90,7 @@ export WM_COMPILE_OPTION=Opt
 #   ~libz   : without libz compression
 #   ~rpath  : without rpath handling [MacOS]
 #   +openmp : with openmp
+#             for clang optional add offload arch, i.e for amd MI300A +openmp:gfx942
 #   ~openmp : without openmp
 #   +ccache : use ccache
 #   +xcrun  : use xcrun and native compilers [MacOS]
@@ -97,6 +98,7 @@ export WM_COMPILE_OPTION=Opt
 #   ccache=... : ccache command (unquoted, single/double or <> quoted)
 #   version=... : compiler suffix (eg, version=11 -> gcc-11)
 #export WM_COMPILE_CONTROL="+strict"
+#export WM_COMPILE_CONTROL="+openmp:gfx942 +link-ld"
 
 # [WM_MPLIB] - MPI implementation:
 # = SYSTEMOPENMPI | OPENMPI | SYSTEMMPI | MPI | MPICH | MPICH-GM |

--- a/src/OpenFOAM/matrices/lduMatrix/lduAddressing/lduInterfaceFields/lduInterfaceField/lduInterfaceField.H
+++ b/src/OpenFOAM/matrices/lduMatrix/lduAddressing/lduInterfaceFields/lduInterfaceField/lduInterfaceField.H
@@ -7,6 +7,7 @@
 -------------------------------------------------------------------------------
     Copyright (C) 2011-2013 OpenFOAM Foundation
     Copyright (C) 2019-2023 OpenCFD Ltd.
+    Copyright (C) 2023 Advanced Micro Devices, Inc. All rights reserved.
 -------------------------------------------------------------------------------
 License
     This file is part of OpenFOAM.
@@ -43,6 +44,16 @@ SourceFiles
 #include "lduAddressing.H"
 #include "primitiveFieldsFwd.H"
 #include "Pstream.H"
+
+#ifdef USE_OMP
+#include <omp.h>
+    #ifndef OMP_UNIFIED_MEMORY_REQUIRED
+    #define OMP_UNIFIED_MEMORY_REQUIRED
+    #pragma omp requires unified_shared_memory
+    #endif
+
+#include "AtomicAccumulator.H"
+#endif
 
 // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
 

--- a/src/OpenFOAM/primitives/AtomicAccumulator/AtomicAccumulator.H
+++ b/src/OpenFOAM/primitives/AtomicAccumulator/AtomicAccumulator.H
@@ -1,0 +1,61 @@
+/*---------------------------------------------------------------------------*\
+  =========                 |
+  \\      /  F ield         | OpenFOAM: The Open Source CFD Toolbox
+   \\    /   O peration     |
+    \\  /    A nd           | www.openfoam.com
+     \\/     M anipulation  |
+-------------------------------------------------------------------------------
+    Copyright (C) 2023 Advanced Micro Devices, Inc. All rights reserved.
+-------------------------------------------------------------------------------
+License
+    This file is part of OpenFOAM.
+
+    OpenFOAM is free software: you can redistribute it and/or modify it
+    under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    OpenFOAM is distributed in the hope that it will be useful, but WITHOUT
+    ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+    FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+    for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with OpenFOAM.  If not, see <http://www.gnu.org/licenses/>.
+
+Class
+    Foam::AtomicAccumulator
+
+Description
+    Atomic operations of scalars and vectors
+
+SourceFiles
+    AtomicAccumulatorI.H
+    
+\*---------------------------------------------------------------------------*/
+
+#ifndef AtomicAccumulator_H
+#define AtomicAccumulator_H
+
+#include "VectorSpace.H"
+#include "VectorSpaceOps.H"
+#include "macros.H"
+#include "ops.H"
+#include <type_traits>
+
+#ifdef USE_OMP
+#include <omp.h>
+    #ifndef OMP_UNIFIED_MEMORY_REQUIRED
+    #define OMP_UNIFIED_MEMORY_REQUIRED
+    #pragma omp requires unified_shared_memory
+    #endif
+#endif
+
+#include "AtomicAccumulatorScalar.H"
+#include "AtomicAccumulatorVector.H"
+
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+#endif
+
+// ************************************************************************* //

--- a/src/OpenFOAM/primitives/AtomicAccumulator/AtomicAccumulatorScalar.H
+++ b/src/OpenFOAM/primitives/AtomicAccumulator/AtomicAccumulatorScalar.H
@@ -1,0 +1,90 @@
+/*---------------------------------------------------------------------------*\
+  =========                 |
+  \\      /  F ield         | OpenFOAM: The Open Source CFD Toolbox
+   \\    /   O peration     |
+    \\  /    A nd           | www.openfoam.com
+     \\/     M anipulation  |
+-------------------------------------------------------------------------------
+    Copyright (C) 2023 Advanced Micro Devices, Inc. All rights reserved.
+-------------------------------------------------------------------------------
+License
+    This file is part of OpenFOAM.
+
+    OpenFOAM is free software: you can redistribute it and/or modify it
+    under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    OpenFOAM is distributed in the hope that it will be useful, but WITHOUT
+    ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+    FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+    for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with OpenFOAM.  If not, see <http://www.gnu.org/licenses/>.
+
+Class
+    Foam::AtomicAccumulator
+
+Description
+    Atomic operations of scalars
+
+SourceFiles
+    AtomicAccumulatorScalarI.H
+    
+\*---------------------------------------------------------------------------*/
+
+#ifndef AtomicAccumulatorScalar_H
+#define AtomicAccumulatorScalar_H
+
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+namespace Foam
+{
+
+/*---------------------------------------------------------------------------*\
+                         Class AtomicAccumulator Declaration
+\*---------------------------------------------------------------------------*/
+
+template<typename T>
+class AtomicAccumulator
+{
+    // Private Data
+
+        T* val;
+
+public:
+
+    // Constructors
+
+        //- Construct from components
+        AtomicAccumulator(T& ref);
+
+    // Member Operators
+
+        inline void operator+=(const T& rhs);
+
+        inline void operator-=(const T& rhs);
+};
+
+// * * * * * * * * * * * * * * * * * Traits  * * * * * * * * * * * * * * * * //
+
+template <typename T>
+inline typename std::enable_if<std::is_scalar<T>::value, AtomicAccumulator<T>>::type atomicAccumulator(T& ref)
+{
+    return AtomicAccumulator<T>(ref);
+}
+
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+#include "AtomicAccumulatorScalarI.H"
+
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+} // End namespace Foam
+
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+#endif
+
+// ************************************************************************* //

--- a/src/OpenFOAM/primitives/AtomicAccumulator/AtomicAccumulatorScalarI.H
+++ b/src/OpenFOAM/primitives/AtomicAccumulator/AtomicAccumulatorScalarI.H
@@ -1,0 +1,53 @@
+/*---------------------------------------------------------------------------*\
+  =========                 |
+  \\      /  F ield         | OpenFOAM: The Open Source CFD Toolbox
+   \\    /   O peration     |
+    \\  /    A nd           | www.openfoam.com
+     \\/     M anipulation  |
+-------------------------------------------------------------------------------
+    Copyright (C) 2023 Advanced Micro Devices, Inc. All rights reserved.
+-------------------------------------------------------------------------------
+License
+    This file is part of OpenFOAM.
+
+    OpenFOAM is free software: you can redistribute it and/or modify it
+    under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    OpenFOAM is distributed in the hope that it will be useful, but WITHOUT
+    ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+    FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+    for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with OpenFOAM.  If not, see <http://www.gnu.org/licenses/>.
+
+\*---------------------------------------------------------------------------*/
+
+// * * * * * * * * * * * * * * * * Constructors  * * * * * * * * * * * * * * //
+template<typename T>
+AtomicAccumulator<T>::AtomicAccumulator (T& ref) 
+: 
+    val(&ref) 
+{}
+
+// * * * * * * * * * * * * * * * Member Operators  * * * * * * * * * * * * * //
+template<typename T>
+inline void AtomicAccumulator<T>::operator+=(const T& rhs)
+{
+    #pragma omp atomic update
+    *val += rhs;
+}
+
+template<typename T>
+inline void AtomicAccumulator<T>::operator-=(const T& rhs)
+{
+    #pragma omp atomic update
+    *val -= rhs;
+}
+
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+
+// ************************************************************************* //

--- a/src/OpenFOAM/primitives/AtomicAccumulator/AtomicAccumulatorVector.H
+++ b/src/OpenFOAM/primitives/AtomicAccumulator/AtomicAccumulatorVector.H
@@ -1,0 +1,90 @@
+/*---------------------------------------------------------------------------*\
+  =========                 |
+  \\      /  F ield         | OpenFOAM: The Open Source CFD Toolbox
+   \\    /   O peration     |
+    \\  /    A nd           | www.openfoam.com
+     \\/     M anipulation  |
+-------------------------------------------------------------------------------
+    Copyright (C) 2023 Advanced Micro Devices, Inc. All rights reserved.
+-------------------------------------------------------------------------------
+License
+    This file is part of OpenFOAM.
+
+    OpenFOAM is free software: you can redistribute it and/or modify it
+    under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    OpenFOAM is distributed in the hope that it will be useful, but WITHOUT
+    ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+    FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+    for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with OpenFOAM.  If not, see <http://www.gnu.org/licenses/>.
+
+Class
+    Foam::AtomicAccumulator
+
+Description
+    Atomic operations of vectors
+
+SourceFiles
+    AtomicAccumulatorVectorI.H
+    
+\*---------------------------------------------------------------------------*/
+
+#ifndef AtomicAccumulatorVector_H
+#define AtomicAccumulatorVector_H
+
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+namespace Foam
+{
+
+/*---------------------------------------------------------------------------*\
+            Class AtomicAccumulator<VectorSpace<...>> Declaration
+\*---------------------------------------------------------------------------*/
+
+template<class Form, class Cmpt, direction Ncmpts>
+class AtomicAccumulator<VectorSpace<Form, Cmpt, Ncmpts>>
+{
+    // Private Data
+        VectorSpace<Form, Cmpt, Ncmpts>* val;
+
+public:
+    
+    // Constructors
+
+        //- Construct from components
+        AtomicAccumulator(VectorSpace<Form, Cmpt, Ncmpts> &ref);
+
+    // Member Operators
+
+        inline void operator+=(const VectorSpace<Form, Cmpt, Ncmpts>& rhs);
+
+        inline void operator-=(const VectorSpace<Form, Cmpt, Ncmpts>& rhs);
+};
+
+
+// * * * * * * * * * * * * * * * * * Traits  * * * * * * * * * * * * * * * * //
+
+template <class Form, class Cmpt, direction Ncmpts>
+inline AtomicAccumulator<VectorSpace<Form, Cmpt, Ncmpts>> atomicAccumulator(VectorSpace<Form, Cmpt, Ncmpts>& ref)
+{
+    return AtomicAccumulator<VectorSpace<Form, Cmpt, Ncmpts>>(ref);
+}
+
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+#include "AtomicAccumulatorVectorI.H"
+
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+} // End namespace Foam
+
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+#endif
+
+// ************************************************************************* //

--- a/src/OpenFOAM/primitives/AtomicAccumulator/AtomicAccumulatorVectorI.H
+++ b/src/OpenFOAM/primitives/AtomicAccumulator/AtomicAccumulatorVectorI.H
@@ -1,0 +1,52 @@
+/*---------------------------------------------------------------------------*\
+  =========                 |
+  \\      /  F ield         | OpenFOAM: The Open Source CFD Toolbox
+   \\    /   O peration     |
+    \\  /    A nd           | www.openfoam.com
+     \\/     M anipulation  |
+-------------------------------------------------------------------------------
+    Copyright (C) 2023 Advanced Micro Devices, Inc. All rights reserved.
+-------------------------------------------------------------------------------
+License
+    This file is part of OpenFOAM.
+
+    OpenFOAM is free software: you can redistribute it and/or modify it
+    under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    OpenFOAM is distributed in the hope that it will be useful, but WITHOUT
+    ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+    FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+    for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with OpenFOAM.  If not, see <http://www.gnu.org/licenses/>.
+
+\*---------------------------------------------------------------------------*/
+
+// * * * * * * * * * * * * * * * * Constructors  * * * * * * * * * * * * * * //
+template <class Form, class Cmpt, direction Ncmpts>
+AtomicAccumulator<VectorSpace<Form, Cmpt, Ncmpts>>::AtomicAccumulator (VectorSpace<Form, Cmpt, Ncmpts> &ref) 
+: 
+    val(&ref) 
+{}
+
+// * * * * * * * * * * * * * * * Member Operators  * * * * * * * * * * * * * //
+template <class Form, class Cmpt, direction Ncmpts>
+inline void AtomicAccumulator<VectorSpace<Form, Cmpt, Ncmpts>>::operator+=(const VectorSpace<Form, Cmpt, Ncmpts>& rhs)
+{
+    VectorSpaceOps<Ncmpts,0>::eqOp(*val, rhs, atomicPlusEqOp<Cmpt>());
+}
+
+template <class Form, class Cmpt, direction Ncmpts>
+inline void AtomicAccumulator<VectorSpace<Form, Cmpt, Ncmpts>>::operator-=(const VectorSpace<Form, Cmpt, Ncmpts>& rhs)
+{
+    VectorSpaceOps<Ncmpts,0>::eqOp(*val, rhs, atomicMinusEqOp<Cmpt>());
+}
+
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+
+
+
+// ************************************************************************* //

--- a/wmake/rules/General/Clang/c++
+++ b/wmake/rules/General/Clang/c++
@@ -3,7 +3,7 @@
 #------------------------------------------------------------------------------
 SUFFIXES   += .C .cc .cpp .cxx
 
-CC         := clang++$(COMPILER_VERSION) -std=c++14
+CC         := clang++$(COMPILER_VERSION) -std=c++17
 
 c++ARCH    :=
 c++DBUG    :=

--- a/wmake/rules/General/Clang/openmp
+++ b/wmake/rules/General/Clang/openmp
@@ -1,1 +1,18 @@
-openmp-gomp
+# Flags for compiling/linking openmp
+# -
+
+COMP_OPENMP = -fopenmp -fopenmp-version=51
+
+LINK_OPENMP =
+
+WM_OMP_OFFLOAD_ARCH=$(patsubst +openmp:%,%,$(filter +openmp:%,$(WM_COMPILE_CONTROL)))
+
+ifneq ($(WM_OMP_OFFLOAD_ARCH),)
+
+        COMP_OPENMP += -fno-fast-math --offload-arch=${WM_OMP_OFFLOAD_ARCH}
+
+endif
+
+#specific to openfoam_hmm
+COMP_OPENMP += -DUSE_OMP
+# ----------------------------------------------------------------------------

--- a/wmake/rules/General/Clang/openmp-gomp
+++ b/wmake/rules/General/Clang/openmp-gomp
@@ -1,9 +1,0 @@
-# Flags for compiling/linking openmp
-# -
-# Clang provides 'omp' and a link for 'gomp'.
-# With 'gomp' we can also use system libs.
-
-COMP_OPENMP = -DUSE_OMP -fopenmp --offload-arch=gfx90a -fopenmp-target-fast -fopenmp-version=51 -fno-fast-math -Wno-conditional-type-mismatch
-LINK_OPENMP = -lgomp
-
-# -----------------------------------------------------------------------------

--- a/wmake/rules/General/Clang/openmp-omp
+++ b/wmake/rules/General/Clang/openmp-omp
@@ -1,6 +1,0 @@
-# Flags for compiling/linking openmp
-
-COMP_OPENMP = -fopenmp
-LINK_OPENMP = -lomp
-
-# -----------------------------------------------------------------------------

--- a/wmake/rules/General/general
+++ b/wmake/rules/General/general
@@ -58,7 +58,6 @@ endif
 ifeq  (,$(findstring ~openmp,$(WM_COMPILE_CONTROL)))
 ifneq (,$(findstring +openmp,$(WM_COMPILE_CONTROL)))
     c++FLAGS  += $(COMP_OPENMP)
-    cFLAGS  += $(COMP_OPENMP)
 endif
 endif
 

--- a/wmake/rules/General/general
+++ b/wmake/rules/General/general
@@ -58,6 +58,7 @@ endif
 ifeq  (,$(findstring ~openmp,$(WM_COMPILE_CONTROL)))
 ifneq (,$(findstring +openmp,$(WM_COMPILE_CONTROL)))
     c++FLAGS  += $(COMP_OPENMP)
+    cFLAGS  += $(COMP_OPENMP)
 endif
 endif
 


### PR DESCRIPTION
- update Clang rules to enable openmp target offloading
- note on env variable to set in Readme.md